### PR TITLE
[V2] overc-installer: support to rootfs encryption

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -76,6 +76,7 @@ cat << EOF
     --ttyconsoledev: set dev used for tty console
     --ttyconsolecn: set container name for providing agetty
     --privilegedcn: set container name for privileged
+    --encrypt: encrypt the rootfs
 
 EOF
 }
@@ -88,6 +89,7 @@ fi
 btrfs=0
 ttyconsolecn=""
 ttyconsoledev="ttyS0"
+do_encryption=0
 while [ $# -gt 0 ]; do
     case "$1" in
     --config) 
@@ -121,6 +123,9 @@ while [ $# -gt 0 ]; do
     --partition_layout)
             FDISK_PARTITION_LAYOUT_INPUT="$2"
             shift
+            ;;
+    --encrypt)
+            do_encryption=1
             ;;
          *) break
             ;;
@@ -185,6 +190,22 @@ fi
 
 if [ -v CONTAINER_PREFIX -a -n "$CONTAINER_PREFIX" ] ; then
     export CNAME_PREFIX="--prefix $CONTAINER_PREFIX"
+fi
+
+if [ $do_encryption -eq 1 ] ; then
+    which luks-setup.sh >/dev/null 2>&1
+    if [ $? -eq 1 ]; then
+        echo "WARNING: --encrypt ignored due to missing luks-setup.sh. \
+Install cryptfs-tpm2"
+        do_encryption=0
+    fi
+
+    which cryptsetup >/dev/null 2>&1
+    if [ $? -eq 1 ]; then
+        echo "WARNING: --encrypt ignored due to missing cryptsetup. \
+Install cryptsetup"
+        do_encryption=0
+    fi
 fi
 
 get_container_name_by_prop()
@@ -357,6 +378,12 @@ mkfs.vfat -I -n $BOOTLABEL /dev/${fs_dev}1
 ## define the device file names for rootfs and lxc filesystem
 rootfs_dev=${fs_dev}3
 lxc_fs_dev=${fs_dev}4
+
+if [ $do_encryption -eq 1 ]; then
+    ## Evict all objects for the first creation.
+    luks-setup.sh -f -e -d /dev/${rootfs_dev} -n "${ROOTLABEL}_encrypted"
+    rootfs_dev="mapper/${ROOTLABEL}_encrypted"
+fi
 
 if [ $btrfs -eq 0 ]; then
     debugmsg ${DEBUG_INFO} "[INFO]: creating / (ext4)"
@@ -937,7 +964,13 @@ else
 fi
 
 rmdir ${TMPMNT}
-	
+
+if [ $do_encryption -eq 1 ]; then
+    echo "INFO: Closing LUKS ..."
+
+    cryptsetup luksClose "${ROOTLABEL}_encrypted"
+fi
+
 # don't run this on a host!!
 # sync ; sync ; echo 3> /proc/sys/vm/drop_caches
 # echo o > /proc/sysrq-trigger

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -353,17 +353,22 @@ mkswap -L $SWAPLABEL /dev/${fs_dev}2
 set -e
 debugmsg ${DEBUG_INFO} "[INFO]: creating /boot (vfat)"
 mkfs.vfat -I -n $BOOTLABEL /dev/${fs_dev}1
+
+## define the device file names for rootfs and lxc filesystem
+rootfs_dev=${fs_dev}3
+lxc_fs_dev=${fs_dev}4
+
 if [ $btrfs -eq 0 ]; then
     debugmsg ${DEBUG_INFO} "[INFO]: creating / (ext4)"
-    mkfs.ext4 -v -L $ROOTLABEL /dev/${fs_dev}3
-    mkfs.ext4 -v -L $LXCLABEL /dev/${fs_dev}4
+    mkfs.ext4 -v -L $ROOTLABEL /dev/${rootfs_dev}
+    mkfs.ext4 -v -L $LXCLABEL /dev/${lxc_fs_dev}
 else
     debugmsg ${DEBUG_INFO} "[INFO]: creating / (btrfs)"
     set +e
     has_f=`mkfs.btrfs 2>&1 |grep -q '^.*\-f' && echo -f`
     set -e
-    mkfs.btrfs $has_f -L $ROOTLABEL /dev/${fs_dev}3
-    mkfs.btrfs $has_f -L $LXCLABEL /dev/${fs_dev}4
+    mkfs.btrfs $has_f -L $ROOTLABEL /dev/${rootfs_dev}
+    mkfs.btrfs $has_f -L $LXCLABEL /dev/${lxc_fs_dev}
 fi
 set +e
 
@@ -372,7 +377,7 @@ if [ -z "${TMPMNT}" ]; then
     export TMPMNT
 fi
 mkdir -p ${TMPMNT}
-mount /dev/${fs_dev}3 ${TMPMNT}
+mount /dev/${rootfs_dev} ${TMPMNT}
 
 if [ $btrfs -eq 0 ]; then
 	mkdir ${TMPMNT}/boot
@@ -445,7 +450,7 @@ if [ $btrfs -eq 1 ]; then
 	sync
 	umount ${TMPMNT}/rootfs/mnt
 	umount ${TMPMNT}/
-	mount -o subvolid=${subvol} /dev/${fs_dev}3 ${TMPMNT}
+	mount -o subvolid=${subvol} /dev/${rootfs_dev} ${TMPMNT}
 	mount /dev/${fs_dev}1 ${TMPMNT}/mnt
 	cd ${TMPMNT}/
 fi
@@ -608,7 +613,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
     if [ ! -d ${TMPMNT}/var/lib/lxc ]; then
         mkdir -p ${TMPMNT}/var/lib/lxc
     fi
-    mount /dev/${fs_dev}4 ${TMPMNT}/var/lib/lxc
+    mount /dev/${lxc_fs_dev} ${TMPMNT}/var/lib/lxc
 
     mkdir -p ${TMPMNT}/tmp
 
@@ -618,7 +623,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
         subvol=`btrfs subvolume list ${TMPMNT}/var/lib/lxc | awk '{print $2;}'`
         sync
         umount ${TMPMNT}/var/lib/lxc
-        mount -o subvol=workdir /dev/${fs_dev}4 ${TMPMNT}/var/lib/lxc
+        mount -o subvol=workdir /dev/${lxc_fs_dev} ${TMPMNT}/var/lib/lxc
     fi
 
     # deal with static IPs and the "Networking Prime"
@@ -842,7 +847,7 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
         if [ -z "$subvol" ]; then
             debugmsg ${DEBUG_WARN} "[WARNING]: Could not get subvolume id, thus cannot create factory reset snapshot"
         else
-            mount /dev/${fs_dev}4 ${TMPMNT}/var/lib/lxc
+            mount /dev/${lxc_fs_dev} ${TMPMNT}/var/lib/lxc
             btrfs subvolume set-default $subvol ${TMPMNT}/var/lib/lxc
             btrfs subvolume snapshot ${TMPMNT}/var/lib/lxc/workdir ${TMPMNT}/var/lib/lxc/${FACTORY_SNAPSHOT}
             #snapshot subvolume recursively
@@ -918,7 +923,7 @@ if [ $btrfs -eq 0 ]; then
 else
 	debugmsg ${DEBUG_INFO} "[INFO]: Creating a snapshot of rootfs for recovery."
 	#mount the root subvolume
-	mount -o subvolid=5 /dev/${fs_dev}3 ${TMPMNT}
+	mount -o subvolid=5 /dev/${rootfs_dev} ${TMPMNT}
 	if [ -e "${TMPMNT}/rootfs" ]; then
 		btrfs subvolume snapshot ${TMPMNT}/rootfs ${TMPMNT}/rootfs_bakup
 		btrfs subvolume snapshot ${TMPMNT}/rootfs ${TMPMNT}/${FACTORY_SNAPSHOT}

--- a/sbin/functions.sh
+++ b/sbin/functions.sh
@@ -606,6 +606,13 @@ install_grub()
 	    ${CMD_GRUB_INSTALL} --root-directory=${mountpoint} --no-floppy hd0 # > /dev/null 2>&1
 	else
 	    ${CMD_GRUB_INSTALL} --root-directory=${mountpoint} --no-floppy --recheck /dev/${device} # > /dev/null 2>&1
+	    # Fedora 24 employs grub2-install which installs the files to DIR/grub2
+	    if [ -d "${mountpoint}/boot/grub2" ]; then
+		if ! mv "${mountpoint}/boot/grub2" "${mountpoint}/boot/grub"; then
+		    debugmsg ${DEBUG_CRIT} "ERROR: Unable to rename ${mountpoint}/boot/grub2"
+		    return 1
+		fi
+	    fi
 	fi
 	if [ $? -ne 0 ]
 	then


### PR DESCRIPTION
Changelog since v1:
- Use --encrypt option instead of --encryption
- Clarify the support to rootfs encryption/decryption only
- Give the useful info if the required packages are not installed

Quick change diff:
```
diff --git a/installers/cubeit-installer b/installers/cubeit-installer
index bf57572..b1ad440 100755
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -76,7 +76,7 @@ cat << EOF
     --ttyconsoledev: set dev used for tty console
     --ttyconsolecn: set container name for providing agetty
     --privilegedcn: set container name for privileged
-    --encryption: encrypt rootfs and filesystem for container
+    --encrypt: encrypt the rootfs
 
 EOF
 }
@@ -124,7 +124,7 @@ while [ $# -gt 0 ]; do
             FDISK_PARTITION_LAYOUT_INPUT="$2"
             shift
             ;;
-    --encryption)
+    --encrypt)
             do_encryption=1
             ;;
          *) break
@@ -193,8 +193,17 @@ if [ -v CONTAINER_PREFIX -a -n "$CONTAINER_PREFIX" ] ; then
 fi
 
 if [ $do_encryption -eq 1 ] ; then
-    if [ ! -x `which luks-setup.sh 2> /dev/null` -o ! -x `which cryptsetup 2> /dev/null` ] ; then
-        echo "WARNING: --encryption ignored"
+    which luks-setup.sh >/dev/null 2>&1
+    if [ $? -eq 1 ]; then
+        echo "WARNING: --encrypt ignored due to missing luks-setup.sh. \
+Install cryptfs-tpm2"
+        do_encryption=0
+    fi
+
+    which cryptsetup >/dev/null 2>&1
+    if [ $? -eq 1 ]; then
+        echo "WARNING: --encrypt ignored due to missing cryptsetup. \
+Install cryptsetup"
         do_encryption=0
     fi
 fi

```