### PR TITLE
cubeit-installer: support IMA signing

### DIFF
--- a/files/grub-usb.cfg
+++ b/files/grub-usb.cfg
@@ -4,6 +4,6 @@ set root=(hd0,1)
 
 menuentry "%DISTRIBUTION% Installer" {
 	set root=(hd0,1)
-	linux /images/%INSTALL_KERNEL% rootwait root=LABEL=%ROOTFS_LABEL%
+	linux /images/%INSTALL_KERNEL% rootwait root=LABEL=%ROOTFS_LABEL% ima_appraise=off
 	initrd /images/%INSTALL_INITRAMFS%
 }

--- a/files/grub-usb.cfg.initramfs-installer
+++ b/files/grub-usb.cfg.initramfs-installer
@@ -8,6 +8,6 @@ terminal serial
 
 menuentry "Initramfs Installer" {
 	set root=(hd0,1)
-	linux /images/%INSTALL_KERNEL% rootwait
+	linux /images/%INSTALL_KERNEL% rootwait ima_appraise=off
         initrd /images/%INSTALL_INITRAMFS%
 }

--- a/files/menu.lst.initramfs-installer
+++ b/files/menu.lst.initramfs-installer
@@ -2,5 +2,5 @@ default		0
 timeout		5
 
 title		%DISTRIBUTION% Installer
-kernel		/images/bzImage rootwait root=LABEL=%ROOTFS_LABEL%
+kernel		/images/bzImage rootwait root=LABEL=%ROOTFS_LABEL% ima_appraise=off
 initrd		/images/%INSTALL_INITRAMFS%

--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -77,6 +77,7 @@ cat << EOF
     --ttyconsolecn: set container name for providing agetty
     --privilegedcn: set container name for privileged
     --encrypt: encrypt the rootfs
+    --ima-sign: sign the files with IMA signature
 
 EOF
 }
@@ -90,6 +91,7 @@ btrfs=0
 ttyconsolecn=""
 ttyconsoledev="ttyS0"
 do_encryption=0
+do_ima_sign=0
 while [ $# -gt 0 ]; do
     case "$1" in
     --config) 
@@ -126,6 +128,9 @@ while [ $# -gt 0 ]; do
             ;;
     --encrypt)
             do_encryption=1
+            ;;
+    --ima-sign)
+            do_ima_sign=1
             ;;
          *) break
             ;;
@@ -258,6 +263,40 @@ get_prop_isset_by_container()
     done
 
     echo "${ret}"
+}
+
+ima_sign()
+{
+    local root_dir="$1"
+    local mnt_dirs="`grep $root_dir /proc/mounts | awk '{ print $2 }'`"
+
+    for dir in `ls $root_dir`; do
+        local dst_dir="$root_dir/$dir"
+
+        for _dir in $mnt_dirs; do
+            # skip root directory
+            [ "$_dir" = "$root_dir" ] && continue
+
+            local fs_type="`grep $_dir /proc/mounts | awk '{ print $3 }'`"
+            local skip_signing=0
+
+            if [ "$dst_dir" = "$_dir" ]; then
+                if [ $fs_type != "btrfs" -a $fs_type != "ext4" ]; then
+                    skip_signing=1
+                    break
+                fi
+            fi
+        done
+
+        [ $skip_signing -eq 1 ] && continue
+
+        evmctl ima_sign --rsa -r -t f "$dst_dir" && {
+            debugmsg ${DEBUG_INFO} "[INFO]: IMA signing completed for $dst_dir."
+        } || {
+            debugmsg ${DEBUG_INFO} "[ERROR]: IMA signing occurs with error for $dst_dir."
+            exit 1
+        }
+    done
 }
 
 # containers are listed in HDINSTALL_CONTAINERS as:
@@ -475,6 +514,54 @@ if [ -n "$img" ] ; then
 			break
 		done
 	fi
+
+        # repack initramfs as required
+        if [ $do_ima_sign -eq 1 -a -f mnt/initrd ]; then
+            if [ -n "${IMA_POLICY}" -a -f "${IMA_POLICY}" ]; then
+                copy_ima_policy=1
+            else
+                copy_ima_policy=0
+            fi
+
+            if [ -n "${IMA_PUBKEY}" -a -f "${IMA_PUBKEY}" ]; then
+                copy_ima_pubkey=1
+            else
+                copy_ima_pubkey=0
+            fi
+
+            if [ $copy_ima_policy -eq 1 -o $copy_ima_pubkey -eq 1 ]; then
+                topdir="`pwd`"
+                initrd_src="$topdir/mnt/initrd"
+
+                mkdir -p /tmp/initramfs-repack
+                cd /tmp/initramfs-repack
+
+                zcat $initrd_src | cpio -id
+
+                [ $copy_ima_policy -eq 1 ] && {
+                    cp -f "${IMA_POLICY}" etc/ima_policy && {
+                        debugmsg ${DEBUG_INFO} "IMA policy copied"
+                    } || {
+                        debugmsg ${DEBUG_INFO} "[ERROR] Unable to copy IMA policy"
+                        exit 1
+                    }
+		}
+
+                [ $copy_ima_pubkey -eq 1 ] && {
+                    cp -f "${IMA_PUBKEY}" etc/keys/pubkey_evm.pem && {
+                        debugmsg ${DEBUG_INFO} "IMA public key copied"
+                    } || {
+                        debugmsg ${DEBUG_INFO} "[ERROR] Unable to copy IMA public key"
+                        exit 1
+                    }
+		}
+
+                find . | cpio -o -H newc > "$initrd_src"
+                cd -
+                cp -f "$initrd_src" "mnt/${initrd}"
+                rm -rf /tmp/initramfs-repack
+            fi
+        fi
 fi
 
 if [ $btrfs -eq 1 ]; then
@@ -549,6 +636,10 @@ menuentry "$DISTRIBUTION recovery" {
 
 EOF
 
+    if [ $do_ima_sign -eq 1 ]; then
+        sed -i 's/^\s*linux .*/& ima_policy=tcb/' ${TMPMNT}/mnt/grub/grub.cfg
+    fi
+
     debugmsg ${DEBUG_INFO} "[INFO]: grub installed"
     
     # fixups for virtual installs
@@ -586,6 +677,11 @@ EOF
 
 	echo `basename mnt/EFI/BOOT/boot*.efi` >mnt/startup.nsh
 	chmod +x mnt/startup.nsh
+
+        if [ $do_ima_sign -eq 1 ]; then
+            sed -i 's/^\s*chainloader .*/& integrity_audit=1 ima_policy=tcb/' mnt/EFI/BOOT/grub.cfg
+            sed -i 's/^\s*linux .*/& integrity_audit=1 ima_policy=tcb/' mnt/EFI/BOOT/grub.cfg
+        fi
     else
 	install -m 0755 ${SBINDIR}/startup.nsh mnt/
 	sed -i "s/%ROOTLABEL%/${ROOTLABEL}/" mnt/startup.nsh
@@ -619,9 +715,10 @@ sed -i '/^tmpfs/d' ${TMPMNT}/etc/fstab
 sed -i '/^usbdevfs/d' ${TMPMNT}/etc/fstab
 
 echo "LABEL=$SWAPLABEL none swap sw 0 0" >> ${TMPMNT}/etc/fstab
-echo "LABEL=$BOOTLABEL /boot auto defaults 0 0" >> ${TMPMNT}/etc/fstab
+[ $do_ima_sign -eq 1 ] && mount_ops="defaults,iversion" || mount_ops="defaults"
+echo "LABEL=$BOOTLABEL /boot auto $mount_ops 0 0" >> ${TMPMNT}/etc/fstab
 if [ -n "${HDINSTALL_CONTAINERS}" ]; then
-	echo "LABEL=$LXCLABEL /var/lib/lxc auto defaults 0 0" >> ${TMPMNT}/etc/fstab
+	echo "LABEL=$LXCLABEL /var/lib/lxc auto $mount_opts 0 0" >> ${TMPMNT}/etc/fstab
 fi
 
 if [ -e "$INSTALL_SMARTCONFIG" ]; then
@@ -909,6 +1006,9 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
             umount ${TMPMNT}/var/lib/lxc
         fi
     fi
+
+    [ $do_ima_sign -eq 1 ] &&
+        ima_sign "${TMPMNT}/var/lib/lxc"
 fi
 
 if [ -d "${PACKAGESDIR}" ]; then
@@ -940,6 +1040,16 @@ else \\
 fi ; \\
 "
     fi
+fi
+
+if [ $do_ima_sign -eq 1 ]; then
+    [ -n "${IMA_PRIVKEY}" -a -f "${IMA_PRIVKEY}" ] &&
+        cp -f ${IMA_PRIVKEY} ${TMPMNT}/etc/privkey_evm.pem
+
+    [ -n "${IMA_PUBKEY}" -a -f "${IMA_PUBKEY}" ] &&
+        cp -f ${IMA_PUBKEY} ${TMPMNT}/etc/pubkey_evm.pem
+
+    ima_sign "${TMPMNT}"
 fi
 
 debugmsg ${DEBUG_INFO} "[INFO]: performing cleanup"


### PR DESCRIPTION
The overc installer now supports IMA signing with the following features.

- The installer explicitly disables IMA appraise.
- The runtime explicitly enables the default IMA policy and integrityauditing.
- Label all filesystems during installation, including rootfs and lxc fs.
- All executable, shared libraries, kernel modules and firmwares will be protected with the IMA signatures.
- The installer allows to define public key, private key and policy file specified in config-installer.sh during the installation.
- All above behaviors are controlled by --ima-sign.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>