### PR TITLE
cubeit-installer: fix container launch failure if IMA used

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -272,13 +272,13 @@ ima_sign()
 
     for dir in `ls $root_dir`; do
         local dst_dir="$root_dir/$dir"
+	local skip_signing=0
 
         for _dir in $mnt_dirs; do
             # skip root directory
             [ "$_dir" = "$root_dir" ] && continue
 
             local fs_type="`grep $_dir /proc/mounts | awk '{ print $3 }'`"
-            local skip_signing=0
 
             if [ "$dst_dir" = "$_dir" ]; then
                 if [ $fs_type != "btrfs" -a $fs_type != "ext4" ]; then
@@ -1056,6 +1056,10 @@ if [ -n "${HDINSTALL_CONTAINERS}" ]; then
 	    ${f}
 	done
     fi
+
+    [ $do_ima_sign -eq 1 ] &&
+        ima_sign "${TMPMNT}/var/lib/lxc"
+
     sync
     umount ${TMPMNT}/var/lib/lxc
 


### PR DESCRIPTION
The rootfs for a container should be labelled prior to umounting it.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>