### PR TITLE
cubeit-installer: set the fallback to entry number

### DIFF
--- a/installers/cubeit-installer
+++ b/installers/cubeit-installer
@@ -751,7 +751,7 @@ if [ "\${SECURE_OFF}" = "1" ]; then
 fi
 
 menuentry "$DISTRIBUTION" {
-    set fallback="$DISTRIBUTION recovery"
+    set fallback=1
     chainloader /bzImage root=LABEL=$ROOTLABEL ro rootwait initrd=/initrd
 }
 


### PR DESCRIPTION
Current grub doesn't support to set the fallback to title.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>