### PR TITLE
grub cfg: don't explicitly set root prefix

### DIFF
--- a/files/grub-hd.cfg
+++ b/files/grub-hd.cfg
@@ -1,6 +1,5 @@
 set default=0
 set timeout=5
-set root=(hd0,1)
 
 insmod efivar
 get_efivar -f uint8 -s unprovisioned SetupMode
@@ -14,6 +13,6 @@ if [ "${unprovisioned}" = "1" ]; then
 fi
 
 menuentry "%DISTRIBUTION%" {
-	set root=(hd0,1)
 	linux /images/bzImage rootwait root=/dev/sda1
+	initrd /images/initrd
 }

--- a/files/grub-usb.cfg
+++ b/files/grub-usb.cfg
@@ -1,6 +1,5 @@
 set default=0
 set timeout=1
-set root=(hd0,1)
 
 insmod efivar
 get_efivar -f uint8 -s unprovisioned SetupMode
@@ -14,7 +13,6 @@ if [ "${unprovisioned}" = "1" ]; then
 fi
 
 menuentry "%DISTRIBUTION% Installer" {
-	set root=(hd0,1)
 	linux /images/%INSTALL_KERNEL% rootwait root=LABEL=%ROOTFS_LABEL% ima_appraise=off
 	initrd /images/%INSTALL_INITRAMFS%
 }

--- a/files/grub-usb.cfg.initramfs-installer
+++ b/files/grub-usb.cfg.initramfs-installer
@@ -1,6 +1,5 @@
 set default=0
 set timeout=5
-set root=(hd0,1)
 
 serial --unit=0 --speed=9600
 
@@ -18,7 +17,6 @@ if [ "${unprovisioned}" = "1" ]; then
 fi
 
 menuentry "Initramfs Installer" {
-	set root=(hd0,1)
 	linux /images/%INSTALL_KERNEL% rootwait ima_appraise=off
         initrd /images/%INSTALL_INITRAMFS%
 }


### PR DESCRIPTION
The root prefix would be automatically probed if not explicitly
specified and the probed value would point to the device where grub is
installed and it is usually selected by BIOS boot manager. In most cases,
this default behavior is expected, unless an exception occurs.

The usual behavior should determine the setting of the templates, so
explicitly setting root prefix is a bad idea. In most cases, a hard disk
is attached on the target board and the end user may use a USB thumb drive.
This typical hardware setup will be broke by specifying hd0 if both USB
thumb drive and hard disk are on. Without the explicit setting, the boot
device will be simply determined by the BIOS boot order.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>