### PR TITLE
grub configs: enable the user authentication

### DIFF
--- a/files/grub-hd.cfg
+++ b/files/grub-hd.cfg
@@ -2,14 +2,23 @@ set default=0
 set timeout=5
 
 insmod efivar
-get_efivar -f uint8 -s unprovisioned SetupMode
+get_efivar -f uint8 -s secured SecureBoot
 
-if [ "${unprovisioned}" = "1" ]; then
-    set timeout=0
+if [ "${secured}" = "1" ]; then
+    # Enable user authentication to make grub unlockable
+    set superusers="root"
+    # The password is "incendia"
+    password_pbkdf2 root grub.pbkdf2.sha512.10000.0199429A1D632773EF212FB495DA1BBE30B2E6B5C8722FD87D3C77B581AD35A70CD176633B9BF233D09377F38CCFCFCB64729D5FEC40800336629A4B2FC01F7E.CD2C8CDF553C880FF1B56AC9B4B8B6A9BF068C895C1A2128FFCEB745529B6BB3CD273C692452B5998D82091949FAFB1219235387FAEB07D508BAC8A2FFB53628
+else
+    get_efivar -f uint8 -s unprovisioned SetupMode
 
-    menuentry "Automatic Certificate Provision" {
-        chainloader ${prefix}/LockDown.efi
-    }
+    if [ "${unprovisioned}" = "1" ]; then
+        set timeout=0
+
+        menuentry "Automatic Certificate Provision" {
+            chainloader ${prefix}/LockDown.efi
+        }
+    fi
 fi
 
 menuentry "%DISTRIBUTION%" {

--- a/files/grub-usb.cfg
+++ b/files/grub-usb.cfg
@@ -2,14 +2,23 @@ set default=0
 set timeout=1
 
 insmod efivar
-get_efivar -f uint8 -s unprovisioned SetupMode
+get_efivar -f uint8 -s secured SecureBoot
 
-if [ "${unprovisioned}" = "1" ]; then
-    set timeout=0
+if [ "${secured}" = "1" ]; then
+    # Enable user authentication to make grub unlockable
+    set superusers="root"
+    # The password is "incendia"
+    password_pbkdf2 root grub.pbkdf2.sha512.10000.0199429A1D632773EF212FB495DA1BBE30B2E6B5C8722FD87D3C77B581AD35A70CD176633B9BF233D09377F38CCFCFCB64729D5FEC40800336629A4B2FC01F7E.CD2C8CDF553C880FF1B56AC9B4B8B6A9BF068C895C1A2128FFCEB745529B6BB3CD273C692452B5998D82091949FAFB1219235387FAEB07D508BAC8A2FFB53628
+else
+    get_efivar -f uint8 -s unprovisioned SetupMode
 
-    menuentry "Automatic Certificate Provision" {
-        chainloader ${prefix}/LockDown.efi
-    }
+    if [ "${unprovisioned}" = "1" ]; then
+        set timeout=0
+
+        menuentry "Automatic Certificate Provision" {
+            chainloader ${prefix}/LockDown.efi
+        }
+    fi
 fi
 
 menuentry "%DISTRIBUTION% Installer" {

--- a/files/grub-usb.cfg.initramfs-installer
+++ b/files/grub-usb.cfg.initramfs-installer
@@ -6,14 +6,23 @@ serial --unit=0 --speed=9600
 terminal serial
 
 insmod efivar
-get_efivar -f uint8 -s unprovisioned SetupMode
+get_efivar -f uint8 -s secured SecureBoot
 
-if [ "${unprovisioned}" = "1" ]; then
-    set timeout=0
+if [ "${secured}" = "1" ]; then
+    # Enable user authentication to make grub unlockable
+    set superusers="root"
+    # The password is "incendia"
+    password_pbkdf2 root grub.pbkdf2.sha512.10000.0199429A1D632773EF212FB495DA1BBE30B2E6B5C8722FD87D3C77B581AD35A70CD176633B9BF233D09377F38CCFCFCB64729D5FEC40800336629A4B2FC01F7E.CD2C8CDF553C880FF1B56AC9B4B8B6A9BF068C895C1A2128FFCEB745529B6BB3CD273C692452B5998D82091949FAFB1219235387FAEB07D508BAC8A2FFB53628
+else
+    get_efivar -f uint8 -s unprovisioned SetupMode
 
-    menuentry "Automatic Certificate Provision" {
-        chainloader ${prefix}/LockDown.efi
-    }
+    if [ "${unprovisioned}" = "1" ]; then
+        set timeout=0
+
+        menuentry "Automatic Certificate Provision" {
+            chainloader ${prefix}/LockDown.efi
+        }
+    fi
 fi
 
 menuentry "Initramfs Installer" {


### PR DESCRIPTION
The user authentication is a standard grub function, prohibiting entering
into command and edit line modes without password authentication. The user
authentication is only applicable to UEFI secure boot. UEFI secure boot
provides the infrastructure for the chain of trust established from boot
to runtime. Hence, tampering kernel commandline or loading unsigned kernel
may break the chain of trust.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>