### PR TITLE
overc-ctl: do not reboot after rolling back container

### DIFF
--- a/sbin/overc-ctl
+++ b/sbin/overc-ctl
@@ -443,7 +443,7 @@ upgrade_container() {
     create_snapshot || return 1
     if ! eval ${package_manager}_upgrade "${container_name}"; then
         log_error "Upgrade container with ${package_manager} failed, rollback to the latest"
-        rollback_container "true" "true"
+        rollback_container "true" ""
         return 1
     fi
 


### PR DESCRIPTION
This allows all cube-* containers to be able to rollback along with
dom0, which is being controlled by overc.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>